### PR TITLE
Make sure children in GAFMovieClip.hx get their names set even if multiple children share a same name.

### DIFF
--- a/gaf/src/com/github/haxePixiGAF/display/GAFMovieClip.hx
+++ b/gaf/src/com/github/haxePixiGAF/display/GAFMovieClip.hx
@@ -993,9 +993,12 @@ class GAFMovieClip extends GAFContainer implements IAnimatable
 			if(_config.namedParts !=null)
 			{
 				var instanceName:String=_config.namedParts[animationObjectConfig.instanceID];
-				if (instanceName != null && !Reflect.hasField(this,instanceName))
+				if (instanceName != null)
 				{
-					Reflect.setField(this, _config.namedParts[animationObjectConfig.instanceID], displayObject);
+					if(!Reflect.hasField(this, instanceName)
+					{
+						Reflect.setField(this, _config.namedParts[animationObjectConfig.instanceID], displayObject);
+					}
 					displayObject.name=instanceName;
 				}
 			}


### PR DESCRIPTION
Make sure children in GAFMovieClip.hx get their names set even if multiple children share a same name.
@see https://github.com/mathieuanthoine/PixiGAFPlayer/issues/1