### PR TITLE
bug fix: readShort's range is –32768 to 32767, instead of -128 to 127

### DIFF
--- a/gaf/src/com/github/haxePixiGAF/utils/GAFBytesInput.hx
+++ b/gaf/src/com/github/haxePixiGAF/utils/GAFBytesInput.hx
@@ -26,7 +26,7 @@ class GAFBytesInput extends BytesInput {
 	
 	public function readShort():Int {
 		var lByte:Int = readUInt16();
-		return lByte > 128 ? lByte-256 : lByte;
+		return lByte > 32767 ? lByte-65536 : lByte;
 	}	
 	
 	public function readUnsignedShort ():UInt {


### PR DESCRIPTION
 update readShort's range to –32768 to 32767
this also fix the bug where GAFMovieClip's startFrameNo becomes negative if frameNo is greater than 127.